### PR TITLE
feat: add touch gesture controls for editor

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -11,6 +11,7 @@ body {
   margin: 0; padding: 0; height: 100vh;
   background: var(--bg); color: var(--fg);
   font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  overscroll-behavior: none;
 }
 
 /* App shell */
@@ -67,6 +68,10 @@ body:not(.edit-mode) .main { grid-template-columns: 1fr; }
 .canvas-area { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; min-height: 0; }
 .canvas-area .canvas-wrap { min-height: 0; }
 .canvas-surface { padding: 10px; overflow: auto; height: 100%; display: flex; align-items: center; justify-content: center; }
+#outputSurface.canvas-surface {
+  overflow: hidden;
+  touch-action: none;
+}
 .canvas-wrap { background: var(--card); border: 1px solid #1f2937; border-radius: 10px; display: grid; grid-template-rows: auto 1fr; overflow: hidden; }
 .panel-header { padding: 8px 10px; font-size: 12px; color: var(--muted); border-bottom: 1px solid #1f2937; display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .bg-selector { display: flex; gap: 4px; align-items: center; }
@@ -86,6 +91,7 @@ body:not(.edit-mode) .main { grid-template-columns: 1fr; }
 /* Additional preset */
 .bg-lightgray { background: #9ca3af !important; background-image: none !important; }
 canvas { display: block; max-width: 100%; max-height: 100%; width: auto; height: auto; background: #0b1220; border: 1px solid #1f2937; border-radius: 6px; }
+canvas { transform-origin: 0 0; }
 .canvas-surface { overscroll-behavior: contain; }
 #previewCanvas, #outputCanvas { touch-action: none; }
 .pixelated { image-rendering: pixelated; image-rendering: crisp-edges; }


### PR DESCRIPTION
## Summary
- prevent overscroll on the page and disable native scrolling on the editor surface so the canvas can be transformed safely
- add pointer gesture handling to the output canvas to support two-finger pan/pinch, trackpad zoom, and guard painting/move interactions
- reset and apply canvas transforms when the rendered size changes to keep the editor view consistent

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68ca2180b3b883279c552b67457aefdc