### PR TITLE
Refine convert layout and mobile editor controls

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,8 @@
   const methodSelect = document.getElementById('method');
   const qualityInput = document.getElementById('quality');
   const qualityLabel = document.getElementById('qualityLabel');
+  const qualityDecBtn = document.getElementById('qualityDec');
+  const qualityIncBtn = document.getElementById('qualityInc');
   const scaleXInput = document.getElementById('scaleX');
   const scaleYInput = document.getElementById('scaleY');
   const scaleXNum = document.getElementById('scaleXNum');
@@ -59,6 +61,14 @@
   const layersListMobileFull = document.getElementById('layersListMobileFull');
   const addLayerBtnMobile2 = document.getElementById('addLayerBtnMobile2');
   const removeLayerBtnMobile2 = document.getElementById('removeLayerBtnMobile2');
+  const aspectPreset = document.getElementById('aspectPreset');
+  const gridPresetList = document.getElementById('gridPresetList');
+  const gridAspectBadge = document.getElementById('gridAspectBadge');
+  const canvasArea = document.querySelector('.canvas-area');
+  const viewToggleBtn = document.getElementById('viewToggleBtn');
+  const viewToggleLabel = viewToggleBtn?.querySelector('.label') || null;
+  const viewTogglePath = viewToggleBtn?.querySelector('path') || null;
+  const mobileColorInputField = document.getElementById('mobileColorInput');
 
   // Background selector elements
   const previewSurface = document.getElementById('previewSurface');
@@ -68,6 +78,11 @@
   let canvasBgColor = null; // Custom background color
   const statusText = document.getElementById('statusText');
   const toolButtons = Array.from(document.querySelectorAll('.tool-btn[data-tool]'));
+  const ICON_EYE = '<svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" /><circle cx="12" cy="12" r="3" fill="none" stroke="currentColor" stroke-width="1.6" /></svg>';
+  const ICON_EYE_OFF = '<svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 3l18 18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" /><path d="M10.6 10.6a2 2 0 002.8 2.8" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" /><path d="M6.1 6.6C3.9 8.2 2 12 2 12s3.5 6 10 6c1.7 0 3.1-.3 4.3-.8M9.1 5.3C9.9 5.1 10.9 5 12 5c6.5 0 10 6 10 6a16.1 16.1 0 01-2.6 3.6" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" /></svg>';
+  const ICON_DUP = '<svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 9h11v11H9z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" /><path d="M4 4h11v11" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" /></svg>';
+  const ICON_MERGE = '<svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4v10M8 10l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" /><path d="M6 18h12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" /></svg>';
+  const TOOL_LABELS = { pen: 'ペン', eraser: '消しゴム', picker: 'スポイト', line: '直線', rect: '矩形', fill: '塗りつぶし', move: '移動' };
   
   function updateMobileBrushUI() {
     if (mobileBrushSize && brushSizeInput) mobileBrushSize.textContent = String(brushSizeInput.value || '1');
@@ -379,24 +394,40 @@
         const meta = document.createElement('div'); meta.className = 'layer-meta';
         const nameEl = document.createElement('div'); nameEl.className = 'layer-name';
         const tagsEl = document.createElement('div'); tagsEl.className = 'layer-tags';
-        const eye = document.createElement('button'); eye.className = 'layer-eye'; eye.type = 'button';
-        const dup = document.createElement('button'); dup.type = 'button'; dup.className = 'layer-btn'; dup.title = '複製'; dup.textContent = '⧉';
-        const merge = document.createElement('button'); merge.type = 'button'; merge.className = 'layer-btn'; merge.title = '下と結合'; merge.textContent = '⇩';
+        const eye = document.createElement('button'); eye.className = 'layer-eye'; eye.type = 'button'; eye.innerHTML = ICON_EYE;
+        const dup = document.createElement('button'); dup.type = 'button'; dup.className = 'layer-btn'; dup.title = '複製'; dup.innerHTML = ICON_DUP;
+        const merge = document.createElement('button'); merge.type = 'button'; merge.className = 'layer-btn'; merge.title = '下と結合'; merge.innerHTML = ICON_MERGE;
 
         if (it.type === 'base') {
-          nameEl.textContent = 'ベース'; tagsEl.textContent = '変換結果';
+          nameEl.textContent = 'ベース';
+          tagsEl.textContent = editingBase ? '編集中' : '';
+          tagsEl.classList.toggle('is-active', Boolean(tagsEl.textContent));
           if (baseVisible === false) el.classList.add('is-hidden');
           if (editingBase) el.classList.add('selected');
           if (baseCanvas.width && baseCanvas.height) tctx.drawImage(baseCanvas, 0, 0, 56, 56);
-          eye.addEventListener('click', (e) => { e.stopPropagation(); baseVisible = !baseVisible; compositeOutput(); });
+          eye.innerHTML = baseVisible ? ICON_EYE : ICON_EYE_OFF;
+          eye.addEventListener('click', (e) => {
+            e.stopPropagation();
+            baseVisible = !baseVisible;
+            eye.innerHTML = baseVisible ? ICON_EYE : ICON_EYE_OFF;
+            compositeOutput();
+          });
           el.addEventListener('click', () => { selectBaseForEditing(); compositeOutput(); updateStatus(); });
         } else {
           const ly = layers[it.index];
-          nameEl.textContent = ly.name || `Layer ${it.index+1}`; tagsEl.textContent = '編集レイヤー';
+          nameEl.textContent = ly.name || `Layer ${it.index+1}`;
+          tagsEl.textContent = (!editingBase && currentLayerIndex === it.index) ? '編集中' : '';
+          tagsEl.classList.toggle('is-active', Boolean(tagsEl.textContent));
           if (ly.visible === false) el.classList.add('is-hidden');
           if (!editingBase && currentLayerIndex === it.index) el.classList.add('selected');
           if (ly.canvas.width && ly.canvas.height) tctx.drawImage(ly.canvas, 0, 0, 56, 56);
-          eye.addEventListener('click', (e) => { e.stopPropagation(); ly.visible = (ly.visible === false) ? true : false; compositeOutput(); });
+          eye.innerHTML = (ly.visible === false) ? ICON_EYE_OFF : ICON_EYE;
+          eye.addEventListener('click', (e) => {
+            e.stopPropagation();
+            ly.visible = (ly.visible === false) ? true : false;
+            eye.innerHTML = (ly.visible === false) ? ICON_EYE_OFF : ICON_EYE;
+            compositeOutput();
+          });
           el.addEventListener('click', () => { selectLayerForEditing(it.index); if (layerSelect) layerSelect.value = String(it.index); compositeOutput(); updateStatus(); });
           nameEl.addEventListener('dblclick', (e) => {
             e.stopPropagation();
@@ -469,6 +500,16 @@
   let lastGridW = parseInt(gridWInput.value || '32', 10) || 32;
   let lastGridH = parseInt(gridHInput.value || '32', 10) || 32;
   let hasPaint = false;
+  let sourceAspect = 1;
+  let currentGridPresets = [];
+  const VIEW_MODES = [
+    { id: 'stack', label: '二分割', icon: 'M6 6h12v4H6zM6 14h12v4H6z' },
+    { id: 'split', label: '横並び', icon: 'M6 6h6v12H6zM12 6h6v12h-6z' },
+    { id: 'preview', label: '元画像', icon: 'M4 12c2.6-4 6-6 8-6s5.4 2 8 6c-2.6 4-6 6-8 6s-5.4-2-8-6zm8 3a3 3 0 100-6 3 3 0 000 6z' },
+    { id: 'output', label: '出力', icon: 'M6 6h12v12H6z' }
+  ];
+  let convertViewMode = canvasArea?.dataset.view || 'stack';
+  let currentViewIndex = Math.max(0, VIEW_MODES.findIndex(v => v.id === convertViewMode));
 
   function clamp(v, lo, hi) { return Math.max(lo, Math.min(hi, v)); }
 
@@ -524,8 +565,28 @@
   // (removed) createCheckerPattern: CSS handles checker background
 
   function updateQualityLabel() {
-    qualityLabel.textContent = String(qualityInput.value);
+    if (!qualityLabel || !qualityInput) return;
+    const value = parseInt(qualityInput.value || qualityInput.min || '1', 10) || 1;
+    qualityLabel.textContent = String(value);
+    const min = parseInt(qualityInput.min || '1', 10) || 1;
+    const max = parseInt(qualityInput.max || '8', 10) || 8;
+    if (qualityDecBtn) qualityDecBtn.disabled = value <= min;
+    if (qualityIncBtn) qualityIncBtn.disabled = value >= max;
   }
+
+  function adjustQuality(delta) {
+    if (!qualityInput) return;
+    const min = parseInt(qualityInput.min || '1', 10) || 1;
+    const max = parseInt(qualityInput.max || '8', 10) || 8;
+    const current = parseInt(qualityInput.value || String(min), 10) || min;
+    const next = Math.max(min, Math.min(max, current + delta));
+    if (next === current) return;
+    qualityInput.value = String(next);
+    updateQualityLabel();
+    qualityInput.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  updateQualityLabel();
 
   // Offscreen composed view
   const compCanvas = document.createElement('canvas');
@@ -590,6 +651,111 @@
     }
   }
 
+  function applyViewModeToUI() {
+    if (!canvasArea) return;
+    const mode = VIEW_MODES[currentViewIndex] || VIEW_MODES[0];
+    canvasArea.dataset.view = mode.id;
+    if (viewToggleLabel) viewToggleLabel.textContent = mode.label;
+    if (viewTogglePath) viewTogglePath.setAttribute('d', mode.icon);
+  }
+
+  function setViewMode(mode) {
+    const idx = VIEW_MODES.findIndex(v => v.id === mode);
+    currentViewIndex = idx >= 0 ? idx : 0;
+    if (appMode === 'normalize') convertViewMode = VIEW_MODES[currentViewIndex].id;
+    applyViewModeToUI();
+  }
+
+  function cycleViewMode() {
+    currentViewIndex = (currentViewIndex + 1) % VIEW_MODES.length;
+    convertViewMode = VIEW_MODES[currentViewIndex].id;
+    applyViewModeToUI();
+  }
+
+  function updateAspectBadge() {
+    if (!gridWInput || !gridHInput) return;
+    const gw = Math.max(1, parseInt(gridWInput.value || '1', 10));
+    const gh = Math.max(1, parseInt(gridHInput.value || '1', 10));
+    const text = simplifyAspectFromWH(gw, gh);
+    if (gridAspect) gridAspect.value = text;
+    if (gridAspectBadge) gridAspectBadge.textContent = text;
+  }
+
+  function highlightGridPreset() {
+    if (!gridPresetList) return;
+    const gw = Math.max(1, parseInt(gridWInput.value || '0', 10));
+    const gh = Math.max(1, parseInt(gridHInput.value || '0', 10));
+    gridPresetList.querySelectorAll('button').forEach(btn => {
+      const bw = parseInt(btn.dataset.w || '0', 10);
+      const bh = parseInt(btn.dataset.h || '0', 10);
+      btn.classList.toggle('active', bw === gw && bh === gh);
+    });
+  }
+
+  function buildGridPresets(ratio) {
+    if (!gridPresetList) return;
+    currentGridPresets = [];
+    gridPresetList.innerHTML = '';
+    const r = (!isFinite(ratio) || ratio <= 0) ? 1 : ratio;
+    const longSides = [16, 24, 32, 48, 64, 96, 128, 160, 192, 224, 256];
+    const seen = new Set();
+    longSides.forEach(side => {
+      let w;
+      let h;
+      if (r >= 1) {
+        w = side;
+        h = Math.max(1, Math.round(side / r));
+      } else {
+        h = side;
+        w = Math.max(1, Math.round(side * r));
+      }
+      if (w > 256 || h > 256) return;
+      const key = `${w}x${h}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      currentGridPresets.push({ w, h });
+    });
+    if (currentGridPresets.length === 0) {
+      currentGridPresets.push({ w: 32, h: 32 });
+    }
+    currentGridPresets.sort((a, b) => (a.w * a.h) - (b.w * b.h));
+    currentGridPresets = currentGridPresets.slice(0, 6);
+    currentGridPresets.forEach(preset => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.dataset.w = String(preset.w);
+      btn.dataset.h = String(preset.h);
+      btn.textContent = `${preset.w} × ${preset.h}`;
+      gridPresetList.appendChild(btn);
+    });
+    highlightGridPreset();
+  }
+
+  function applyPresetSelection(preference = 'nearest') {
+    if (!currentGridPresets.length) return;
+    let target = currentGridPresets[0];
+    if (preference === 'nearest') {
+      const currentW = Math.max(1, parseInt(gridWInput.value || '0', 10));
+      target = currentGridPresets.reduce((best, preset) => {
+        if (!best) return preset;
+        const diff = Math.abs(preset.w - currentW);
+        const bestDiff = Math.abs(best.w - currentW);
+        return diff < bestDiff ? preset : best;
+      }, currentGridPresets[0]);
+    }
+    gridWInput.value = String(target.w);
+    gridHInput.value = String(target.h);
+    updateAspectBadge();
+    highlightGridPreset();
+  }
+
+  function setAspectRatio(ratio) {
+    const approx = approximateAspect(ratio || 1);
+    const text = `${approx.w}:${approx.h}`;
+    if (gridAspect) gridAspect.value = text;
+    if (gridAspectBadge) gridAspectBadge.textContent = text;
+  }
+
   function syncOffsetRanges() {
     const LIM = 500; // Reduced from 10000 to 500 for better slider usability
     offsetXRange.min = String(-LIM);
@@ -611,6 +777,26 @@
     const v = parseFloat(s);
     if (!isNaN(v) && v > 0) return v;
     return null;
+  }
+
+  function approximateAspect(ratio) {
+    if (!isFinite(ratio) || ratio <= 0) return { w: 1, h: 1 };
+    let best = { w: 1, h: 1, err: Math.abs(ratio - 1) };
+    for (let h = 1; h <= 64; h++) {
+      const w = Math.max(1, Math.round(ratio * h));
+      const approx = w / h;
+      const err = Math.abs(approx - ratio);
+      if (err < best.err) best = { w, h, err };
+    }
+    return { w: best.w, h: best.h };
+  }
+
+  function simplifyAspectFromWH(w, h) {
+    const a = Math.max(1, Math.round(w));
+    const b = Math.max(1, Math.round(h));
+    const gcd = (x, y) => (y ? gcd(y, x % y) : x);
+    const g = gcd(a, b);
+    return `${Math.round(a / g)}:${Math.round(b / g)}`;
   }
 
   let adjustingGrid = false;
@@ -800,40 +986,48 @@
   }
 
   // Event wiring
-  fileInput.addEventListener('change', async (e) => {
-    console.log('File input changed');
-    const f = e.target.files && e.target.files[0];
-    if (!f) {
-      console.log('No file selected');
-      return;
-    }
+  if (fileInput) {
+    fileInput.addEventListener('change', async (e) => {
+      const f = e.target.files && e.target.files[0];
+      if (!f) {
+        fileInput.value = '';
+        return;
+      }
 
-    console.log('File selected:', f.name);
-    statusText.textContent = '画像を読み込み中...';
+      statusText.textContent = '画像を読み込み中...';
 
-    try {
-      img = await readImage(f);
-      console.log('Image loaded successfully');
+      try {
+        img = await readImage(f);
 
-      // Fit source into srcCanvas (keep original size for fidelity)
-      srcCanvas.width = img.naturalWidth;
-      srcCanvas.height = img.naturalHeight;
-      srcCtx.clearRect(0, 0, srcCanvas.width, srcCanvas.height);
-      srcCtx.drawImage(img, 0, 0);
+        // Fit source into srcCanvas (keep original size for fidelity)
+        srcCanvas.width = img.naturalWidth;
+        srcCanvas.height = img.naturalHeight;
+        srcCtx.clearRect(0, 0, srcCanvas.width, srcCanvas.height);
+        srcCtx.drawImage(img, 0, 0);
 
-      // Reset offsets
-      offsetXInput.value = '0';
-      offsetYInput.value = '0';
-      offsetXRange.value = '0';
-      offsetYRange.value = '0';
+        sourceAspect = img.naturalWidth / img.naturalHeight;
+        setAspectRatio(sourceAspect);
+        if (aspectPreset) aspectPreset.value = 'auto';
+        buildGridPresets(sourceAspect);
+        applyPresetSelection('nearest');
+        updateAspectBadge();
+        highlightGridPreset();
 
-      statusText.textContent = '画像を読み込みました';
-      render();
-    } catch (error) {
-      console.error('Error loading image:', error);
-      statusText.textContent = 'エラー: 画像の読み込みに失敗しました';
-    }
-  });
+        // Reset offsets
+        offsetXInput.value = '0';
+        offsetYInput.value = '0';
+        offsetXRange.value = '0';
+        offsetYRange.value = '0';
+
+        statusText.textContent = '画像を読み込みました';
+        render();
+      } catch (error) {
+        console.error('画像の読み込みに失敗しました', error);
+        statusText.textContent = 'エラー: 画像の読み込みに失敗しました';
+      }
+      fileInput.value = '';
+    });
+  }
 
   [gridWInput, gridHInput, methodSelect, qualityInput,
    scaleXInput, scaleYInput, scaleXNum, scaleYNum,
@@ -870,14 +1064,7 @@
           gridWInput.value = String(lastGridW);
           gridHInput.value = String(lastGridH);
         } else {
-          lastGridW = newW; lastGridH = newH;
-          hasPaint = false; baseUndo = []; baseRedo = [];
-          // resize base and all layers
-          baseCanvas.width = newW; baseCanvas.height = newH; baseCtx.clearRect(0,0,newW,newH);
-          layers.forEach(ly => { ly.canvas.width = newW; ly.canvas.height = newH; ly.ctx.clearRect(0,0,newW,newH); ly.undo = []; ly.redo = []; });
-          // keep current selection references
-          if (editingBase) { paintCanvas = baseCanvas; paintCtx = baseCtx; }
-          else if (layers[currentLayerIndex]) { paintCanvas = layers[currentLayerIndex].canvas; paintCtx = layers[currentLayerIndex].ctx; }
+          applyGridResize(newW, newH);
         }
       }
     }
@@ -894,12 +1081,39 @@
 
   // Grid aspect locking
   let adjustingGridFlag = false;
+
+  function applyGridResize(newW, newH) {
+    lastGridW = newW;
+    lastGridH = newH;
+    hasPaint = false;
+    baseUndo = [];
+    baseRedo = [];
+    baseCanvas.width = newW;
+    baseCanvas.height = newH;
+    baseCtx.clearRect(0, 0, newW, newH);
+    layers.forEach(ly => {
+      ly.canvas.width = newW;
+      ly.canvas.height = newH;
+      ly.ctx.clearRect(0, 0, newW, newH);
+      ly.undo = [];
+      ly.redo = [];
+    });
+    if (editingBase) {
+      paintCanvas = baseCanvas;
+      paintCtx = baseCtx;
+    } else if (layers[currentLayerIndex]) {
+      paintCanvas = layers[currentLayerIndex].canvas;
+      paintCtx = layers[currentLayerIndex].ctx;
+    }
+  }
   gridWInput.addEventListener('input', () => {
     if (adjustingGridFlag) return;
     adjustingGridFlag = true;
     applyGridLock('W');
     adjustingGridFlag = false;
     render();
+    updateAspectBadge();
+    highlightGridPreset();
   });
   gridHInput.addEventListener('input', () => {
     if (adjustingGridFlag) return;
@@ -907,26 +1121,98 @@
     applyGridLock('H');
     adjustingGridFlag = false;
     render();
+    updateAspectBadge();
+    highlightGridPreset();
   });
-  gridAspect.addEventListener('change', () => { applyGridLock('W'); render(); });
+  gridAspect.addEventListener('change', () => {
+    applyGridLock('W');
+    render();
+    updateAspectBadge();
+    highlightGridPreset();
+  });
+
+  if (gridLockAspect) {
+    gridLockAspect.addEventListener('change', () => {
+      if (gridLockAspect.checked) {
+        updateAspectBadge();
+        highlightGridPreset();
+      }
+    });
+  }
+
+  if (gridPresetList) {
+    gridPresetList.addEventListener('click', (e) => {
+      const btn = e.target.closest('button');
+      if (!btn) return;
+      const w = parseInt(btn.dataset.w || '0', 10);
+      const h = parseInt(btn.dataset.h || '0', 10);
+      if (!w || !h) return;
+      if (appMode === 'edit' && (w !== lastGridW || h !== lastGridH)) {
+        const ok = confirm('グリッドサイズ（画像サイズ）を変更すると、ペイントはクリアされます。続行しますか？');
+        if (!ok) return;
+        applyGridResize(w, h);
+      }
+      gridWInput.value = String(w);
+      gridHInput.value = String(h);
+      updateAspectBadge();
+      highlightGridPreset();
+      render();
+    });
+  }
+
+  if (aspectPreset) {
+    aspectPreset.addEventListener('change', () => {
+      let ratio = sourceAspect;
+      if (aspectPreset.value && aspectPreset.value !== 'auto') {
+        ratio = parseAspect(aspectPreset.value) || ratio;
+      }
+      setAspectRatio(ratio);
+      buildGridPresets(ratio);
+      applyPresetSelection(aspectPreset.value === 'auto' ? 'nearest' : 'first');
+      highlightGridPreset();
+      render();
+    });
+  }
+
+  if (viewToggleBtn) {
+    viewToggleBtn.addEventListener('click', () => {
+      if (appMode !== 'normalize') return;
+      cycleViewMode();
+    });
+  }
 
   downloadBtn.addEventListener('click', exportPNG);
   undoBtn.addEventListener('click', undoPaint);
   redoBtn.addEventListener('click', redoPaint);
   clearPaintBtn.addEventListener('click', clearPaint);
-  if (openFileBtn) {
-    openFileBtn.addEventListener('click', () => {
-      console.log('Open file button clicked');
-      if (fileInput) {
-        console.log('File input found, triggering click');
-        fileInput.click();
+  function openImagePicker() {
+    if (!fileInput) {
+      statusText.textContent = 'エラー: ファイル入力が見つかりません';
+      return;
+    }
+    try {
+      if (typeof fileInput.showPicker === 'function') {
+        fileInput.showPicker();
       } else {
-        console.error('File input not found');
-        statusText.textContent = 'エラー: ファイル入力が見つかりません';
+        fileInput.click();
       }
+    } catch (err) {
+      fileInput.click();
+    }
+  }
+
+  if (openFileBtn) {
+    openFileBtn.addEventListener('click', (event) => {
+      event.preventDefault();
+      openImagePicker();
     });
-  } else {
-    console.error('Open file button not found');
+  }
+
+  if (qualityDecBtn) {
+    qualityDecBtn.addEventListener('click', () => adjustQuality(-1));
+  }
+  if (qualityIncBtn) {
+    qualityIncBtn.addEventListener('click', () => adjustQuality(1));
   }
   if (exportToggle && exportPopover) {
     exportToggle.addEventListener('click', (e) => {
@@ -979,7 +1265,33 @@
     brushSizeInput.value = String(v);
     updateMobileBrushUI();
   });
-  if (mobileColorBtn) mobileColorBtn.addEventListener('click', () => { if (colorInput) colorInput.click(); });
+  if (mobileColorBtn) {
+    mobileColorBtn.addEventListener('click', () => {
+      const target = mobileColorInputField || colorInput;
+      if (!target) return;
+      try {
+        if (typeof target.showPicker === 'function') {
+          target.showPicker();
+        } else {
+          target.click();
+        }
+      } catch (err) {
+        target.click();
+      }
+    });
+  }
+  if (mobileColorInputField) {
+    const syncMobileColor = () => {
+      const value = mobileColorInputField.value;
+      if (colorInput) {
+        colorInput.value = value;
+        colorInput.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+      updateMobileColorChip();
+    };
+    mobileColorInputField.addEventListener('input', syncMobileColor);
+    mobileColorInputField.addEventListener('change', syncMobileColor);
+  }
   if (layersToggleMobile && layersModal) layersToggleMobile.addEventListener('click', (e) => {
     e.stopPropagation();
     layersModal.classList.remove('hidden');
@@ -1042,6 +1354,8 @@
   function setMode(mode) {
     appMode = mode;
     if (mode === 'edit') {
+      convertViewMode = VIEW_MODES[currentViewIndex]?.id || convertViewMode;
+      setViewMode('output');
       lastGridW = parseInt(gridWInput.value || '32', 10) || 32;
       lastGridH = parseInt(gridHInput.value || '32', 10) || 32;
       // 初回はベースを編集対象にして、消しゴムなどが効くように
@@ -1052,6 +1366,9 @@
       }
       syncToolButtons();
       compositeOutput();
+    }
+    if (mode === 'normalize') {
+      setViewMode(convertViewMode);
     }
     updateModeUI();
     if (mode === 'normalize') {
@@ -1086,7 +1403,11 @@
     });
   }
   if (colorInput) {
-    colorInput.addEventListener('input', () => { updateCurrentColorIndicator(); updateMobileColorChip(); });
+    colorInput.addEventListener('input', () => {
+      if (mobileColorInputField) mobileColorInputField.value = colorInput.value;
+      updateCurrentColorIndicator();
+      updateMobileColorChip();
+    });
   }
   if (alphaInput) {
     alphaInput.addEventListener('input', () => { updateCurrentColorIndicator(); updateMobileColorChip(); });
@@ -1151,15 +1472,16 @@
   // Status bar
   function updateStatus() {
     if (!statusText) return;
+    if (appMode !== 'edit') {
+      statusText.textContent = '';
+      return;
+    }
     const gw = outputCanvas?.width || 0;
     const gh = outputCanvas?.height || 0;
-    const tool = toolSelect?.value || '-';
-    const mode = appMode === 'edit' ? '編集' : '変換';
-    const target = editingBase ? 'ベース' : `レイヤー${currentLayerIndex+1}`;
-    const col = colorInput?.value || '#000000';
-    const a = alphaInput ? parseInt(alphaInput.value||'255',10) : 255;
-    const gridOn = showGrid ? (showGrid.checked ? 'ON' : 'OFF') : 'ON';
-    statusText.textContent = `モード: ${mode} | ツール: ${tool} | 対象: ${target} | グリッド: ${gw}x${gh} | 色: ${col} / α:${a} | プレビュー格子:${gridOn}`;
+    const toolKey = toolSelect?.value || '-';
+    const toolLabel = TOOL_LABELS[toolKey] || toolKey;
+    const target = editingBase ? 'ベース' : `レイヤー ${currentLayerIndex + 1}`;
+    statusText.textContent = `ツール ${toolLabel} ／ サイズ ${gw}×${gh} ／ 対象 ${target}`;
   }
 
   // Removed legacy stepper handlers (buttons not present in UI)
@@ -1167,6 +1489,10 @@
   // Init
   updateQualityLabel();
   updateModeUI();
+  updateAspectBadge();
+  buildGridPresets(parseAspect(gridAspect?.value) || 1);
+  highlightGridPreset();
+  applyViewModeToUI();
   // sync numeric to ranges initial
   scaleXNum.value = scaleXInput.value;
   scaleYNum.value = scaleYInput.value;
@@ -1182,6 +1508,7 @@
   // Init mobile UI indicators
   updateMobileBrushUI();
   updateMobileColorChip();
+  if (mobileColorInputField && colorInput) mobileColorInputField.value = colorInput.value;
 
   // Grid visibility toggle
   if (showGrid) {

--- a/index.html
+++ b/index.html
@@ -11,8 +11,13 @@
       <div class="titlebar">
         <div class="title">Pixel Art Converter</div>
         <div class="title-actions">
-          <button id="openFileBtn" class="ghost">画像を開く</button>
-          <button id="exportToggle" class="ghost">書き出し</button>
+          <button id="exportToggle" class="ghost compact" type="button" title="書き出し">
+            <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M12 16V4m0 0l4 4m-4-4L8 8" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+              <rect x="4" y="14" width="16" height="6" rx="1.5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+            <span class="visually-hidden">書き出し</span>
+          </button>
           <div id="exportPopover" class="popover hidden">
             <div class="popover-title">書き出し設定</div>
             <label>倍率 <input type="number" id="exportScale" min="1" max="64" step="1" value="1" class="num"></label>
@@ -26,25 +31,84 @@
         <aside class="sidebar">
           <div class="tool-group paint-only">
             <div class="tool-title">ツール</div>
-            <button class="tool-btn" data-tool="pen" title="ペン">🖊️</button>
-            <button class="tool-btn" data-tool="eraser" title="消しゴム">🧽</button>
-            <button class="tool-btn" data-tool="picker" title="スポイト">🎯</button>
-            <button class="tool-btn" data-tool="line" title="直線">📏</button>
-            <button class="tool-btn" data-tool="rect" title="矩形">▭</button>
-            <button class="tool-btn" data-tool="fill" title="塗りつぶし">🪣</button>
-            <button class="tool-btn" data-tool="move" title="移動">✋</button>
+            <button class="tool-btn" data-tool="pen" type="button" title="ペン">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M4 16.5V20h3.5L17 10.5l-3.5-3.5L4 16.5z" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M14.5 7l2.5-2.5a2 2 0 012.8 0l.2.2a2 2 0 010 2.8L17.5 10" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+              <span class="visually-hidden">ペン</span>
+            </button>
+            <button class="tool-btn" data-tool="eraser" type="button" title="消しゴム">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M4 15l8.5-8.5a2 2 0 012.8 0L20 11.2a2 2 0 010 2.8L14.8 19a2 2 0 01-1.4.6H8.5a2 2 0 01-1.4-.6L4 17" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+              <span class="visually-hidden">消しゴム</span>
+            </button>
+            <button class="tool-btn" data-tool="picker" type="button" title="スポイト">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M13.5 5.5l-1 1 5 5 1-1a3 3 0 000-4.2l-.8-.8a3 3 0 00-4.2 0z" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M4.5 19.5l6-6" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M7.5 16.5l-2 2" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+              <span class="visually-hidden">スポイト</span>
+            </button>
+            <button class="tool-btn" data-tool="line" type="button" title="直線">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M6 18L18 6" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" />
+              </svg>
+              <span class="visually-hidden">直線</span>
+            </button>
+            <button class="tool-btn" data-tool="rect" type="button" title="矩形">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="5" y="5" width="14" height="14" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.7" />
+              </svg>
+              <span class="visually-hidden">矩形</span>
+            </button>
+            <button class="tool-btn" data-tool="fill" type="button" title="塗りつぶし">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M4 12l6-6 7.5 7.5a2.1 2.1 0 01-1.5 3.6H7.6a2.1 2.1 0 01-2.1-2.1z" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M17.5 7.5l2-2" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" />
+                <path d="M19 15.5c0 .8.6 2 1.5 2s1.5-1.2 1.5-2-.6-1.5-1.5-1.5S19 14.7 19 15.5z" fill="none" stroke="currentColor" stroke-width="1.4" />
+              </svg>
+              <span class="visually-hidden">塗りつぶし</span>
+            </button>
+            <button class="tool-btn" data-tool="move" type="button" title="移動">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 4v16m0-16l-2.5 2.5M12 4l2.5 2.5M12 20l-2.5-2.5M12 20l2.5-2.5M4 12h16M4 12l2.5-2.5M4 12l2.5 2.5M20 12l-2.5-2.5M20 12l-2.5 2.5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+              <span class="visually-hidden">移動</span>
+            </button>
           </div>
 
           <div class="tool-group paint-only">
             <div class="tool-title">編集</div>
-            <button type="button" id="undoBtn" title="Undo">↶</button>
-            <button type="button" id="redoBtn" title="Redo">↷</button>
-            <button type="button" id="clearPaintBtn" title="レイヤークリア">✕</button>
+            <button type="button" id="undoBtn" class="ghost compact" title="元に戻す">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M7 11L3 7l4-4" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M4 7h8.5a6.5 6.5 0 110 13H8" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+              <span class="visually-hidden">元に戻す</span>
+            </button>
+            <button type="button" id="redoBtn" class="ghost compact" title="やり直す">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M17 11l4-4-4-4" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M20 7h-8.5a6.5 6.5 0 100 13H16" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+              <span class="visually-hidden">やり直す</span>
+            </button>
+            <button type="button" id="clearPaintBtn" class="ghost compact" title="レイヤーをクリア">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M5 7h14" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" />
+                <path d="M9 7V5h6v2" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M8 7v11a1 1 0 001 1h6a1 1 0 001-1V7" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+              <span class="visually-hidden">クリア</span>
+            </button>
           </div>
 
           <div class="tool-group paint-only">
             <div class="tool-title">カラー</div>
-            <input type="color" id="color" value="#ff4d4d"/>
+            <input type="color" id="color" value="#ff4d4d" />
             <label class="mini">不透明度 <input type="range" id="alpha" min="0" max="255" value="255"></label>
           </div>
 
@@ -57,7 +121,6 @@
               </select>
             </label>
             <label class="mini">サイズ <input type="number" id="brushSize" min="1" max="16" value="1" class="num"></label>
-            <!-- 保持のための隠しセレクト -->
             <select id="tool" class="visually-hidden">
               <option value="pen" selected>ペン</option>
               <option value="eraser">消しゴム</option>
@@ -73,76 +136,138 @@
         <section class="workspace">
           <div class="mode-bar">
             <div class="mode-steps">
-              <div class="step" data-step="convert">1 変換</div>
-              <div class="arrow">→</div>
-              <div class="step" data-step="edit">2 編集</div>
+              <div class="step" data-step="convert">変換</div>
+              <div class="mode-arrow" aria-hidden="true">
+                <svg class="icon" viewBox="0 0 24 24">
+                  <path d="M5 12h14m0 0l-4-4m4 4l-4 4" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </div>
+              <div class="step" data-step="edit">編集</div>
               <div class="spacer"></div>
-              <button id="backToConvertBtn" class="ghost hidden">変換に戻る</button>
-              <button id="finalizeBtn" class="primary">編集に進む</button>
+              <button id="viewToggleBtn" class="ghost compact" type="button" title="ビュー切替">
+                <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M5 6h6v6H5zM13 6h6v6h-6zM5 14h14v4H5z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" />
+                </svg>
+                <span class="label">二分割</span>
+              </button>
+              <button id="backToConvertBtn" class="ghost hidden" type="button">戻る</button>
+              <button id="finalizeBtn" class="primary" type="button">編集に進む</button>
             </div>
           </div>
 
           <div class="topbar">
-            <div class="group normalize-only">
-              <div class="group-title">変換方法</div>
-              <div class="row">
-                <label>色の決め方
+            <div class="control-card normalize-only">
+              <div class="card-header">
+                <span class="card-title">カラー</span>
+              </div>
+              <div class="card-body">
+                <label class="field">
+                  <span>方式</span>
                   <select id="method">
-                    <option value="mode">最頻色（ブロック内で最も多い色）</option>
-                    <option value="center" selected>中心（ブロック中心の色）</option>
-                    <option value="average">平均（ブロック平均色）</option>
+                    <option value="mode">最頻色</option>
+                    <option value="center" selected>中心色</option>
+                    <option value="average">平均色</option>
                   </select>
                 </label>
-                <label>サンプリング密度 <input type="range" id="quality" min="1" max="8" value="3"> <span id="qualityLabel">3</span></label>
+                <label class="field">
+                  <span>精度</span>
+                  <div class="stepper" role="group" aria-label="精度調整">
+                    <button type="button" id="qualityDec" class="step-btn" aria-label="精度を下げる">
+                      <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M6 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
+                      </svg>
+                    </button>
+                    <span id="qualityLabel" class="step-value">3</span>
+                    <button type="button" id="qualityInc" class="step-btn" aria-label="精度を上げる">
+                      <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
+                      </svg>
+                    </button>
+                  </div>
+                  <input type="range" id="quality" min="1" max="8" value="3" class="visually-hidden" />
+                </label>
               </div>
             </div>
 
-            <div class="group normalize-only">
-              <div class="group-title">グリッド設定（出力サイズ）</div>
-              <div class="row">
-                <label>W <input type="number" id="gridW" min="1" max="256" value="32" class="num"></label>
-                <label>H <input type="number" id="gridH" min="1" max="256" value="32" class="num"></label>
-                <label><input type="checkbox" id="gridLockAspect" checked> 比率を固定</label>
-                <label>比率（W:H）<input type="text" id="gridAspect" value="1:1" class="num" placeholder="1:1"></label>
-                <label><input type="checkbox" id="showGrid" checked> グリッドを表示</label>
+            <div class="control-card normalize-only">
+              <div class="card-header">
+                <span class="card-title">キャンバス</span>
+                <div class="aspect-chip" id="gridAspectBadge">1:1</div>
+              </div>
+              <div class="card-body">
+                <label class="field">
+                  <span>比率</span>
+                  <select id="aspectPreset">
+                    <option value="auto">元画像</option>
+                    <option value="1:1">1:1</option>
+                    <option value="4:3">4:3</option>
+                    <option value="3:4">3:4</option>
+                    <option value="16:9">16:9</option>
+                    <option value="9:16">9:16</option>
+                  </select>
+                </label>
+                <div class="preset-row" id="gridPresetList" role="group" aria-label="グリッドプリセット"></div>
+                <div class="field-row">
+                  <label>幅 <input type="number" id="gridW" min="1" max="256" value="32" class="num"></label>
+                  <label>高さ <input type="number" id="gridH" min="1" max="256" value="32" class="num"></label>
+                  <label class="switch"><input type="checkbox" id="gridLockAspect" checked> 比率固定</label>
+                  <label class="switch"><input type="checkbox" id="showGrid" checked> グリッド</label>
+                </div>
+                <input type="hidden" id="gridAspect" value="1:1">
               </div>
             </div>
 
-            <div class="group normalize-only">
-              <div class="group-title">拡大縮小</div>
-              <div class="row">
-                <label>X
-                  <input type="range" id="scaleX" min="0.1" max="2" step="0.1" value="1">
-                  <input type="number" id="scaleXNum" min="0.1" max="2" step="0.1" value="1" class="num">
+            <div class="control-card normalize-only">
+              <div class="card-header">
+                <span class="card-title">スケール</span>
+              </div>
+              <div class="card-body">
+                <label class="field compact">
+                  <span>X倍率</span>
+                  <div class="range-field">
+                    <input type="range" id="scaleX" min="0.1" max="2" step="0.1" value="1">
+                    <input type="number" id="scaleXNum" min="0.1" max="2" step="0.1" value="1" class="num">
+                  </div>
                 </label>
-                <label>Y
-                  <input type="range" id="scaleY" min="0.1" max="2" step="0.1" value="1">
-                  <input type="number" id="scaleYNum" min="0.1" max="2" step="0.1" value="1" class="num">
+                <label class="field compact">
+                  <span>Y倍率</span>
+                  <div class="range-field">
+                    <input type="range" id="scaleY" min="0.1" max="2" step="0.1" value="1">
+                    <input type="number" id="scaleYNum" min="0.1" max="2" step="0.1" value="1" class="num">
+                  </div>
                 </label>
-                <label><input type="checkbox" id="lockAspect" checked> 縦横比を固定</label>
+                <label class="switch"><input type="checkbox" id="lockAspect" checked> 縦横比を固定</label>
               </div>
             </div>
 
-            <div class="group normalize-only">
-              <div class="group-title">位置調整</div>
-              <div class="row">
-                <label>X
-                  <input type="range" id="offsetXRange" min="0" max="0" step="1" value="0">
-                  <input type="number" id="offsetX" value="0" class="num">
+            <div class="control-card normalize-only">
+              <div class="card-header">
+                <span class="card-title">オフセット</span>
+              </div>
+              <div class="card-body">
+                <label class="field compact">
+                  <span>X</span>
+                  <div class="range-field">
+                    <input type="range" id="offsetXRange" min="0" max="0" step="1" value="0">
+                    <input type="number" id="offsetX" value="0" class="num">
+                  </div>
                 </label>
-                <label>Y
-                  <input type="range" id="offsetYRange" min="0" max="0" step="1" value="0">
-                  <input type="number" id="offsetY" value="0" class="num">
+                <label class="field compact">
+                  <span>Y</span>
+                  <div class="range-field">
+                    <input type="range" id="offsetYRange" min="0" max="0" step="1" value="0">
+                    <input type="number" id="offsetY" value="0" class="num">
+                  </div>
                 </label>
-                <div class="hint">プレビュー上をドラッグしても位置を動かせます</div>
+                <div class="hint">プレビュー上をドラッグしても移動できます</div>
               </div>
             </div>
           </div>
 
-          <div class="canvas-area">
+          <div class="canvas-area" data-view="stack">
             <div class="canvas-wrap" id="previewWrap">
               <div class="panel-header">
-                <span>元画像（ビュー）＋グリッド</span>
+                <span>元画像プレビュー</span>
               </div>
               <div class="canvas-surface checker" id="previewSurface"><canvas id="previewCanvas" width="512" height="512"></canvas></div>
             </div>
@@ -150,24 +275,77 @@
               <div class="panel-header">
                 <span>ピクセル編集</span>
                 <div class="mobile-tools" aria-label="ツール(モバイル)">
-                  <!-- よく使う順に整理: ペン/消しゴム/塗り/スポイト/直線/矩形/移動 -->
-                  <button class="tool-btn" data-tool="pen" title="ペン">🖊️</button>
-                  <button class="tool-btn" data-tool="eraser" title="消しゴム">🧽</button>
-                  <button class="tool-btn" data-tool="fill" title="塗りつぶし">🪣</button>
-                  <button class="tool-btn" data-tool="picker" title="スポイト">🎯</button>
-                  <button class="tool-btn" data-tool="line" title="直線">📏</button>
-                  <button class="tool-btn" data-tool="rect" title="矩形">▭</button>
-                  <button class="tool-btn" data-tool="move" title="移動">✋</button>
+                  <button class="tool-btn" data-tool="pen" type="button" title="ペン">
+                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M4 16.5V20h3.5L17 10.5l-3.5-3.5L4 16.5z" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+                      <path d="M14.5 7l2.5-2.5a2 2 0 012.8 0l.2.2a2 2 0 010 2.8L17.5 10" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+                    </svg>
+                  </button>
+                  <button class="tool-btn" data-tool="eraser" type="button" title="消しゴム">
+                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M4 15l8.5-8.5a2 2 0 012.8 0L20 11.2a2 2 0 010 2.8L14.8 19a2 2 0 01-1.4.6H8.5a2 2 0 01-1.4-.6L4 17" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+                    </svg>
+                  </button>
+                  <button class="tool-btn" data-tool="fill" type="button" title="塗りつぶし">
+                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M4 12l6-6 7.5 7.5a2.1 2.1 0 01-1.5 3.6H7.6a2.1 2.1 0 01-2.1-2.1z" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+                      <path d="M17.5 7.5l2-2" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" />
+                      <path d="M19 15.5c0 .8.6 2 1.5 2s1.5-1.2 1.5-2-.6-1.5-1.5-1.5S19 14.7 19 15.5z" fill="none" stroke="currentColor" stroke-width="1.4" />
+                    </svg>
+                  </button>
+                  <button class="tool-btn" data-tool="picker" type="button" title="スポイト">
+                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M13.5 5.5l-1 1 5 5 1-1a3 3 0 000-4.2l-.8-.8a3 3 0 00-4.2 0z" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+                      <path d="M4.5 19.5l6-6" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+                      <path d="M7.5 16.5l-2 2" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+                    </svg>
+                  </button>
+                  <button class="tool-btn" data-tool="line" type="button" title="直線">
+                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M6 18L18 6" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" />
+                    </svg>
+                  </button>
+                  <button class="tool-btn" data-tool="rect" type="button" title="矩形">
+                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                      <rect x="5" y="5" width="14" height="14" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.7" />
+                    </svg>
+                  </button>
+                  <button class="tool-btn" data-tool="move" type="button" title="移動">
+                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M12 4v16m0-16l-2.5 2.5M12 4l2.5 2.5M12 20l-2.5-2.5M12 20l2.5-2.5M4 12h16M4 12l2.5-2.5M4 12l2.5 2.5M20 12l-2.5-2.5M20 12l-2.5 2.5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+                    </svg>
+                  </button>
                 </div>
                 <div class="bg-selector" aria-label="背景色">
-                  <button class="bg-btn" data-bg="checker" title="チェッカー(透明)">▦</button>
-                  <button class="bg-btn" data-bg="white" title="白">□</button>
-                  <button class="bg-btn" data-bg="black" title="黒">■</button>
-                  <button class="bg-btn" data-bg="lightgray" title="薄灰">▥</button>
-                  <button class="bg-btn" data-bg="gray" title="濃灰">▨</button>
+                  <button class="bg-btn" data-bg="checker" type="button" title="チェッカー(透明)">
+                    <span class="bg-icon bg-icon-checker" aria-hidden="true"></span>
+                    <span class="visually-hidden">チェッカー(透明)</span>
+                  </button>
+                  <button class="bg-btn" data-bg="white" type="button" title="白">
+                    <span class="bg-icon bg-icon-white" aria-hidden="true"></span>
+                    <span class="visually-hidden">白</span>
+                  </button>
+                  <button class="bg-btn" data-bg="black" type="button" title="黒">
+                    <span class="bg-icon bg-icon-black" aria-hidden="true"></span>
+                    <span class="visually-hidden">黒</span>
+                  </button>
+                  <button class="bg-btn" data-bg="lightgray" type="button" title="薄灰">
+                    <span class="bg-icon bg-icon-light" aria-hidden="true"></span>
+                    <span class="visually-hidden">薄灰</span>
+                  </button>
+                  <button class="bg-btn" data-bg="gray" type="button" title="濃灰">
+                    <span class="bg-icon bg-icon-dark" aria-hidden="true"></span>
+                    <span class="visually-hidden">濃灰</span>
+                  </button>
                   <input type="color" id="bgColorPicker" class="bg-color-picker" title="カスタム色">
                 </div>
-                <button id="layersToggle" class="ghost" title="レイヤー">レイヤー</button>
+                <button id="layersToggle" class="ghost compact" type="button" title="レイヤー">
+                  <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M4 8l8-4 8 4-8 4-8-4z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" />
+                    <path d="M4 12l8 4 8-4" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" />
+                  </svg>
+                  <span class="visually-hidden">レイヤー</span>
+                </button>
               </div>
               <div class="canvas-surface checker" id="outputSurface"><canvas id="outputCanvas" width="32" height="32" class="pixelated"></canvas></div>
               <div id="layersPopover" class="popover hidden">
@@ -196,7 +374,11 @@
           </div>
 
           <div class="panel paint-controls" data-collapsible="true">
-            <div class="panel-header"><span>パレット</span><button class="collapse-btn" aria-label="toggle"></button></div>
+            <div class="panel-header"><span>パレット</span><button class="collapse-btn" aria-label="toggle" type="button">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+            </button></div>
             <div class="panel-body">
               <div class="row gap">
                 <button type="button" id="savePaletteBtn">保存</button>
@@ -205,36 +387,88 @@
               <div id="colorHistory" class="color-history"></div>
             </div>
           </div>
-
-          
         </aside>
       </div>
 
       <div class="statusbar">
-        <div id="statusText">準備完了</div>
+        <div id="statusText" aria-live="polite"></div>
       </div>
-      <!-- Mobile bottom toolbar (edit mode) -->
+
       <div class="mobile-bottom-bar" aria-label="モバイル操作">
-        <button id="mobileUndo" title="元に戻す">↶</button>
-        <button id="mobileRedo" title="やり直す">↷</button>
+        <button id="mobileUndo" type="button" title="元に戻す">
+          <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M7 11L3 7l4-4" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+            <path d="M4 7h8.5a6.5 6.5 0 110 13H8" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </button>
+        <button id="mobileRedo" type="button" title="やり直す">
+          <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M17 11l4-4-4-4" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+            <path d="M20 7h-8.5a6.5 6.5 0 100 13H16" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </button>
         <div class="divider"></div>
-        <button class="tool-btn" data-tool="pen" title="ペン">🖊️</button>
-        <button class="tool-btn" data-tool="eraser" title="消しゴム">🧽</button>
-        <button class="tool-btn" data-tool="fill" title="塗りつぶし">🪣</button>
-        <button class="tool-btn" data-tool="picker" title="スポイト">🎯</button>
+        <button class="tool-btn" data-tool="pen" type="button" title="ペン">
+          <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M4 16.5V20h3.5L17 10.5l-3.5-3.5L4 16.5z" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+            <path d="M14.5 7l2.5-2.5a2 2 0 012.8 0l.2.2a2 2 0 010 2.8L17.5 10" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </button>
+        <button class="tool-btn" data-tool="eraser" type="button" title="消しゴム">
+          <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M4 15l8.5-8.5a2 2 0 012.8 0L20 11.2a2 2 0 010 2.8L14.8 19a2 2 0 01-1.4.6H8.5a2 2 0 01-1.4-.6L4 17" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </button>
+        <button class="tool-btn" data-tool="fill" type="button" title="塗りつぶし">
+          <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M4 12l6-6 7.5 7.5a2.1 2.1 0 01-1.5 3.6H7.6a2.1 2.1 0 01-2.1-2.1z" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+            <path d="M17.5 7.5l2-2" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" />
+            <path d="M19 15.5c0 .8.6 2 1.5 2s1.5-1.2 1.5-2-.6-1.5-1.5-1.5S19 14.7 19 15.5z" fill="none" stroke="currentColor" stroke-width="1.4" />
+          </svg>
+        </button>
+        <button class="tool-btn" data-tool="picker" type="button" title="スポイト">
+          <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M13.5 5.5l-1 1 5 5 1-1a3 3 0 000-4.2l-.8-.8a3 3 0 00-4.2 0z" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+            <path d="M4.5 19.5l6-6" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+            <path d="M7.5 16.5l-2 2" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </button>
         <div class="divider"></div>
-        <button id="mobileBrushDec" title="ブラシ縮小">－</button>
+        <button id="mobileBrushDec" type="button" title="ブラシ縮小">
+          <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M6 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
+          </svg>
+        </button>
         <span id="mobileBrushSize" class="label">1</span>
-        <button id="mobileBrushInc" title="ブラシ拡大">＋</button>
+        <button id="mobileBrushInc" type="button" title="ブラシ拡大">
+          <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
+          </svg>
+        </button>
         <div class="divider"></div>
-        <button id="mobileColorBtn" title="色を選択" class="color-chip"></button>
-        <button id="layersToggleMobile" class="ghost" title="レイヤー">レイヤー</button>
+        <button id="mobileColorBtn" type="button" title="色を選択" class="color-chip"></button>
+        <input type="color" id="mobileColorInput" class="visually-hidden" />
+        <button id="layersToggleMobile" class="ghost compact" type="button" title="レイヤー">
+          <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M4 8l8-4 8 4-8 4-8-4z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" />
+            <path d="M4 12l8 4 8-4" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" />
+          </svg>
+        </button>
       </div>
-      <!-- Mobile full-screen Layers modal -->
+
+      <button id="openFileBtn" class="floating-open" type="button" title="画像を開く">
+        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M5 19h14a1 1 0 001-1v-6a1 1 0 00-1-1h-4l-2-3H5a1 1 0 00-1 1v9a1 1 0 001 1z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" />
+          <path d="M12 11v6" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+          <path d="M9 14h6" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+        </svg>
+        <span class="visually-hidden">画像を開く</span>
+      </button>
+
       <div id="layersModal" class="layer-modal hidden" aria-modal="true" role="dialog">
         <div class="layer-modal-header">
           <div class="title">レイヤー</div>
-          <button id="closeLayersModal" class="ghost">閉じる</button>
+          <button id="closeLayersModal" class="ghost" type="button">閉じる</button>
         </div>
         <div id="layersListMobileFull" class="layer-list mobile"></div>
         <div class="layer-modal-footer">
@@ -246,4 +480,4 @@
 
     <script src="app.js"></script>
   </body>
-  </html>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -8,22 +8,27 @@
 
 * { box-sizing: border-box; }
 body {
-  margin: 0; padding: 0; height: 100vh;
+  margin: 0; padding: 0; min-height: 100vh; min-height: 100dvh;
   background: var(--bg); color: var(--fg);
   font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
   overscroll-behavior: none;
 }
 
+.icon { width: 20px; height: 20px; display: block; flex-shrink: 0; }
+.compact .icon { width: 18px; height: 18px; }
+
+button.compact { padding: 6px 8px; border-radius: 8px; }
+
 /* App shell */
-.app-frame { display: grid; grid-template-rows: 44px 1fr 26px; height: 100vh; height: 100svh; }
+.app-frame { display: grid; grid-template-rows: 44px 1fr 26px; height: 100vh; height: 100svh; position: relative; }
 .titlebar {
   display: flex; align-items: center; justify-content: space-between;
   padding: 0 12px; border-bottom: 1px solid #1f2937; background: linear-gradient(180deg, #0b1220, #0a0f1a);
 }
 .title { font-weight: 600; letter-spacing: .2px; color: #cbd5e1; }
-.title-actions { display: flex; gap: 8px; align-items: center; }
-.title-actions { position: relative; }
-.popover { position: absolute; right: 0; top: 36px; width: 260px; background: var(--card); border: 1px solid #1f2937; border-radius: 10px; padding: 10px; display: grid; gap: 10px; z-index: 50; }
+.title-actions { display: flex; gap: 8px; align-items: center; position: relative; }
+.title-actions .compact { border-radius: 10px; }
+.popover { position: absolute; right: 0; top: 40px; width: 260px; background: var(--card); border: 1px solid #1f2937; border-radius: 12px; padding: 12px; display: grid; gap: 12px; z-index: 50; box-shadow: 0 18px 50px rgba(15,23,42,0.6); }
 .popover-title { font-size: 12px; color: var(--muted); }
 
 .main { display: grid; grid-template-columns: 72px 1fr 320px; gap: 12px; padding: 12px; overflow: hidden; min-height: 0; }
@@ -41,31 +46,61 @@ body:not(.edit-mode) .main { grid-template-columns: 1fr; }
 .sidebar input[type="color"] { width: 100%; height: 32px; padding: 0; border: 1px solid #1f2937; background: #0b1220; border-radius: 6px; }
 
 /* Workspace */
-.workspace { display: grid; grid-template-rows: auto minmax(0, auto) 1fr; gap: 12px; min-width: 0; min-height: 0; }
+.workspace { display: grid; grid-template-rows: auto auto 1fr; gap: 12px; min-width: 0; min-height: 0; }
 .mode-bar { background: var(--card); border: 1px solid #1f2937; border-radius: 10px; padding: 8px; position: sticky; top: 0; z-index: 10; }
-.topbar { background: var(--card); border: 1px solid #1f2937; border-radius: 10px; padding: 8px; display: grid; gap: 8px; overflow-y: auto; max-height: 40vh; }
-.group { display: grid; gap: 6px; }
-.group-title { font-size: 11px; color: #94a3b8; padding: 2px 2px 0; }
-.mode-steps { display: flex; align-items: center; gap: 8px; }
-.mode-steps .step { padding: 6px 10px; border-radius: 999px; border: 1px solid #1f2937; background: #0b1220; color: #94a3b8; font-weight: 600; font-size: 12px; }
+.topbar { background: var(--card); border: 1px solid #1f2937; border-radius: 12px; padding: 12px; display: grid; gap: 12px; overflow-y: auto; max-height: 42vh; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); align-content: start; }
+.control-card { background: #0b1220; border: 1px solid #1f2937; border-radius: 12px; display: flex; flex-direction: column; gap: 0; min-width: 0; }
+.control-card .card-header { display: flex; align-items: center; justify-content: space-between; padding: 10px 12px 0; }
+.card-title { font-size: 12px; font-weight: 600; color: #cbd5e1; letter-spacing: .01em; }
+.control-card .card-body { padding: 6px 12px 12px; display: grid; gap: 10px; }
+.field { display: grid; gap: 6px; font-size: 12px; color: #94a3b8; }
+.field.compact { gap: 4px; }
+.range-field { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.range-value { min-width: 28px; text-align: right; font-weight: 600; color: #e2e8f0; }
+.stepper { display: inline-flex; align-items: center; gap: 8px; padding: 4px 8px; border-radius: 999px; border: 1px solid #1f2937; background: #0b1220; }
+.step-btn { background: transparent; border: none; color: #cbd5e1; width: 28px; height: 28px; display: grid; place-items: center; border-radius: 999px; cursor: pointer; transition: background .2s ease, color .2s ease; }
+.step-btn:hover, .step-btn:focus-visible { background: rgba(37,99,235,0.15); color: #bfdbfe; outline: none; }
+.step-btn:disabled { opacity: .35; cursor: not-allowed; background: transparent; color: #475569; }
+.step-value { min-width: 22px; text-align: center; font-weight: 600; color: #e2e8f0; font-variant-numeric: tabular-nums; }
+.preset-row { display: flex; flex-wrap: wrap; gap: 6px; }
+.preset-row button { background: #0d1627; border: 1px solid #1f2937; color: #cbd5e1; padding: 6px 10px; border-radius: 999px; font-size: 12px; cursor: pointer; transition: background .2s ease, border-color .2s ease; }
+.preset-row button:hover { background: #13203a; }
+.preset-row button.active { background: #1d4ed8; border-color: #1e40af; color: #e5e7eb; }
+.field-row { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; }
+.field-row label { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; }
+.aspect-chip { background: rgba(37,99,235,0.15); color: #bfdbfe; font-size: 11px; padding: 4px 10px; border-radius: 999px; border: 1px solid rgba(59,130,246,0.4); }
+.switch { font-size: 12px; color: #94a3b8; display: inline-flex; align-items: center; gap: 6px; }
+.hint { font-size: 11px; color: #64748b; }
+.mode-steps { display: flex; align-items: center; gap: 10px; }
+.mode-steps .step { padding: 6px 14px; border-radius: 999px; border: 1px solid #1f2937; background: #0b1220; color: #94a3b8; font-weight: 600; font-size: 12px; letter-spacing: .02em; }
+.mode-steps .label { font-size: 12px; color: #94a3b8; margin-left: 6px; }
 .mode-steps .step.active { background: #2563eb; color: #e5e7eb; border-color: #1d4ed8; }
-.mode-steps .arrow { color: #475569; }
+.mode-arrow { display: flex; align-items: center; justify-content: center; color: #475569; }
+.mode-arrow .icon { width: 18px; height: 18px; }
 .mode-steps .spacer { flex: 1; }
 .topbar .row { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; }
 .divider { width: 1px; height: 24px; background: #1f2937; }
 /* Mobile bottom toolbar */
-.mobile-bottom-bar { display: none; position: fixed; left: 0; right: 0; bottom: 26px; /* above statusbar */
-  background: rgba(10,15,26,0.95); backdrop-filter: saturate(120%) blur(6px);
-  border-top: 1px solid #1f2937; padding: 6px 8px calc(6px + env(safe-area-inset-bottom));
-  z-index: 100; gap: 6px; align-items: center; justify-content: center; }
-.mobile-bottom-bar { display: none; }
-.mobile-bottom-bar button, .mobile-bottom-bar .tool-btn { background: #0b1220; border: 1px solid #1f2937; color: #e5e7eb; border-radius: 10px; padding: 8px; min-width: 40px; min-height: 40px; font-size: 16px; }
+.mobile-bottom-bar { display: none; position: fixed; left: 0; right: 0; bottom: 0;
+  background: rgba(8,12,22,0.96); backdrop-filter: saturate(140%) blur(14px);
+  border-top: 1px solid #1f2937; padding: 12px 14px calc(18px + env(safe-area-inset-bottom));
+  z-index: 120; gap: 8px; align-items: center; justify-content: flex-start; overflow-x: auto; overflow-y: hidden;
+  box-shadow: 0 -24px 48px rgba(2,6,23,0.75); }
+.mobile-bottom-bar::-webkit-scrollbar { display: none; }
+.mobile-bottom-bar { scrollbar-width: none; }
+.mobile-bottom-bar button, .mobile-bottom-bar .tool-btn { background: #0b1220; border: 1px solid #1f2937; color: #e5e7eb; border-radius: 12px; padding: 10px; min-width: 44px; min-height: 44px; font-size: 16px; flex: 0 0 auto; }
 .mobile-bottom-bar .tool-btn.active { outline: 2px solid #2563eb; background: #0f1a2e; }
-.mobile-bottom-bar .label { min-width: 24px; text-align: center; color: #94a3b8; font-weight: 600; }
-.mobile-bottom-bar .divider { width: 1px; height: 28px; background: #1f2937; }
-.mobile-bottom-bar .color-chip { min-width: 40px; min-height: 40px; border-radius: 8px; border: 1px solid #1f2937; }
+.mobile-bottom-bar .label { min-width: 28px; text-align: center; color: #94a3b8; font-weight: 600; }
+.mobile-bottom-bar .divider { width: 1px; height: 32px; background: #1f2937; flex: 0 0 auto; }
+.mobile-bottom-bar .color-chip { min-width: 44px; min-height: 44px; border-radius: 10px; border: 1px solid #1f2937; }
 
-.canvas-area { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; min-height: 0; }
+.canvas-area { display: grid; gap: 12px; min-height: 0; height: 100%; grid-template-columns: 1fr; grid-template-rows: repeat(2, minmax(0, 1fr)); }
+.canvas-area[data-view="split"] { grid-template-columns: repeat(2, minmax(0, 1fr)); grid-template-rows: 1fr; }
+.canvas-area[data-view="stack"] { grid-template-columns: 1fr; grid-template-rows: repeat(2, minmax(0, 1fr)); }
+.canvas-area[data-view="preview"] { grid-template-rows: 1fr; }
+.canvas-area[data-view="preview"] #outputWrap { display: none; }
+.canvas-area[data-view="output"] { grid-template-rows: 1fr; }
+.canvas-area[data-view="output"] #previewWrap { display: none; }
 .canvas-area .canvas-wrap { min-height: 0; }
 .canvas-surface { padding: 10px; overflow: auto; height: 100%; display: flex; align-items: center; justify-content: center; }
 #outputSurface.canvas-surface {
@@ -75,13 +110,23 @@ body:not(.edit-mode) .main { grid-template-columns: 1fr; }
 .canvas-wrap { background: var(--card); border: 1px solid #1f2937; border-radius: 10px; display: grid; grid-template-rows: auto 1fr; overflow: hidden; }
 .panel-header { padding: 8px 10px; font-size: 12px; color: var(--muted); border-bottom: 1px solid #1f2937; display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .bg-selector { display: flex; gap: 4px; align-items: center; }
-.bg-btn { background: #0b1220; border: 1px solid #1f2937; color: #e5e7eb; border-radius: 4px; padding: 4px 8px; cursor: pointer; font-size: 14px; min-width: 24px; height: 24px; }
+.bg-btn { background: #0b1220; border: 1px solid #1f2937; color: #e5e7eb; border-radius: 6px; padding: 4px; cursor: pointer; min-width: 28px; height: 28px; display: inline-flex; align-items: center; justify-content: center; }
 .bg-btn:hover { background: #1f2937; }
 .bg-btn.active { outline: 2px solid #2563eb; }
-.bg-color-picker { width: 24px; height: 24px; padding: 0; border: 1px solid #1f2937; border-radius: 4px; cursor: pointer; }
-.collapse-btn { background: transparent; border: 1px solid #1f2937; color: #94a3b8; border-radius: 6px; width: 22px; height: 22px; display: grid; place-items: center; cursor: pointer; }
-.collapse-btn::before { content: '▾'; line-height: 1; }
-.panel.collapsed .collapse-btn { transform: rotate(-90deg); }
+.bg-icon { width: 18px; height: 18px; border-radius: 4px; display: inline-block; background: #0b1220; position: relative; overflow: hidden; box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.45); }
+.bg-icon-checker::before,
+.bg-icon-checker::after { content: ''; position: absolute; inset: 0; background-size: 8px 8px; background-position: 0 0, 4px 4px; }
+.bg-icon-checker::before { background-image: linear-gradient(45deg, #1f2937 25%, transparent 25%, transparent 75%, #1f2937 75%, #1f2937); }
+.bg-icon-checker::after { background-image: linear-gradient(45deg, transparent 25%, #111827 25%, #111827 75%, transparent 75%, transparent); opacity: 0.9; }
+.bg-icon-white { background: #ffffff; }
+.bg-icon-black { background: #000000; }
+.bg-icon-light { background: #e2e8f0; }
+.bg-icon-dark { background: #475569; }
+.bg-icon::after { content: ''; position: absolute; inset: 0; border-radius: 4px; box-shadow: inset 0 0 0 1px rgba(15,23,42,0.6); }
+.bg-color-picker { width: 28px; height: 28px; padding: 0; border: 1px solid #1f2937; border-radius: 6px; cursor: pointer; }
+.collapse-btn { background: transparent; border: 1px solid #1f2937; color: #94a3b8; border-radius: 6px; width: 28px; height: 28px; display: grid; place-items: center; cursor: pointer; }
+.collapse-btn .icon { width: 16px; height: 16px; transition: transform .2s ease; }
+.panel.collapsed .collapse-btn .icon { transform: rotate(-90deg); }
 .panel.collapsed .panel-body { display: none; }
 .canvas-surface { padding: 10px; overflow: auto; }
 .checker { background-image: linear-gradient(45deg,#111827 25%,transparent 25%),linear-gradient(-45deg,#111827 25%,transparent 25%),linear-gradient(45deg,transparent 75%,#111827 75%),linear-gradient(-45deg,transparent 75%,#111827 75%); background-size: 20px 20px; background-position: 0 0,0 10px,10px -10px,-10px 0px; }
@@ -117,8 +162,9 @@ button { background: var(--accent); border: none; color: #09310e; padding: 8px 1
 .ghost { background: transparent; color: #94a3b8; border: 1px solid #1f2937; }
 .primary { background: #2563eb; color: #e5e7eb; }
 .num { width: 88px; }
-.stepper button { padding: 4px 8px; margin-left: 4px; background: #374151; color: #e5e7eb; border-radius: 6px; border: 1px solid #1f2937; }
-.stepper button:hover { background: #4b5563; }
+
+.floating-open { position: fixed; right: 24px; bottom: 32px; width: 56px; height: 56px; border-radius: 999px; background: #2563eb; color: #e5e7eb; display: grid; place-items: center; box-shadow: 0 18px 45px rgba(14, 23, 42, 0.6); z-index: 140; border: none; }
+.floating-open .icon { width: 24px; height: 24px; }
 
 /* Mode toggles */
 .hidden { display: none !important; }
@@ -129,10 +175,10 @@ button { background: var(--accent); border: none; color: #09310e; padding: 8px 1
 body:not(.edit-mode) .paint-only { opacity: .5; pointer-events: none; }
 body:not(.edit-mode) .sidebar { display: none; }
 /* Normalize mode: show both preview and output side by side */
-body:not(.edit-mode) .canvas-area { grid-template-columns: 1fr 1fr; }
 /* Edit mode: single surface (output only) */
 .edit-mode #previewWrap { display: none; }
-.edit-mode .canvas-area { grid-template-columns: 1fr; }
+.edit-mode .canvas-area { grid-template-columns: 1fr; grid-template-rows: 1fr; }
+.edit-mode #viewToggleBtn { display: none; }
 
 /* Layer list */
 .layer-list { display: grid; gap: 8px; }
@@ -143,12 +189,14 @@ body:not(.edit-mode) .canvas-area { grid-template-columns: 1fr 1fr; }
 .layer-meta { display: flex; flex-direction: column; gap: 2px; }
 .layer-name { font-size: 12px; color: #e5e7eb; }
 .layer-tags { font-size: 10px; color: #94a3b8; }
-.layer-eye { background: transparent; border: 1px solid #1f2937; color: #94a3b8; border-radius: 6px; width: 28px; height: 28px; display: grid; place-items: center; cursor: pointer; }
-.layer-eye::before { content: '👁️'; }
-.layer-item.is-hidden .layer-eye::before { content: '🚫'; }
-.layer-btn { background: transparent; border: 1px solid #1f2937; color: #94a3b8; border-radius: 6px; width: 28px; height: 28px; display: grid; place-items: center; cursor: pointer; }
+.layer-tags:empty { display: none; }
+.layer-tags.is-active { color: #38bdf8; font-weight: 600; }
+.layer-eye { background: transparent; border: 1px solid #1f2937; color: #94a3b8; border-radius: 6px; width: 32px; height: 32px; display: grid; place-items: center; cursor: pointer; transition: border-color .2s ease, color .2s ease; }
+.layer-eye .icon { width: 18px; height: 18px; }
+.layer-item.is-hidden .layer-eye { color: #ef4444; border-color: #991b1b; }
+.layer-btn { background: transparent; border: 1px solid #1f2937; color: #94a3b8; border-radius: 6px; width: 32px; height: 32px; display: grid; place-items: center; cursor: pointer; }
+.layer-btn .icon { width: 16px; height: 16px; }
 .edit-mode .normalize-only { display: none !important; }
-.edit-mode .canvas-area { grid-template-columns: 1fr; }
 .edit-mode #outputWrap { grid-column: 1 / -1; }
 .edit-mode #outputWrap .canvas-surface { display: flex; align-items: center; justify-content: center; }
 
@@ -163,7 +211,7 @@ body:not(.edit-mode) .canvas-area { grid-template-columns: 1fr 1fr; }
   pointer-events: none; border-radius: 4px;
 }
 /* In convert step, let top tools scroll and keep canvases fully visible */
-body:not(.edit-mode) .topbar { max-height: 40vh; overflow: auto; }
+body:not(.edit-mode) .topbar { max-height: 48vh; overflow: auto; }
 body:not(.edit-mode) #layersToggle, body:not(.edit-mode) #layersPopover { display: none !important; }
 /* Mobile layers modal */
 .layer-modal { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 200; display: grid; grid-template-rows: auto 1fr auto; }
@@ -177,34 +225,37 @@ body:not(.edit-mode) #layersToggle, body:not(.edit-mode) #layersPopover { displa
 
 /* Mobile adjustments */
 @media (max-width: 768px) {
-  .main { grid-template-columns: 1fr; padding: 8px; }
+  html, body { height: 100%; }
+  body { overflow: hidden; }
+  .app-frame { grid-template-rows: 44px 1fr; height: 100vh; height: 100svh; }
+  .statusbar { display: none; }
+  .main { grid-template-columns: 1fr; padding: 8px 10px 12px; overflow-y: auto; }
   .sidebar, .panels { display: none !important; }
-  .topbar { max-height: 15vh; padding: 3px; gap: 3px; font-size: 12px; overflow-y: auto; }
-  .mode-bar { padding: 3px; }
-  .canvas-area { display: grid !important; grid-template-columns: 1fr !important; grid-template-rows: 1fr 1fr !important; gap: 6px !important; }
+  .topbar { padding: 8px; gap: 8px; max-height: 50vh; grid-template-columns: 1fr; }
+  .control-card .card-body { gap: 8px; }
+  .field-row { gap: 8px; }
+  .mode-bar { padding: 6px 8px; }
+  .mode-steps .label { display: none; }
+  .title-actions .compact { padding: 4px 6px; }
+  .canvas-area { gap: 8px; grid-template-columns: 1fr; grid-template-rows: repeat(2, minmax(0, 1fr)); }
   .canvas-area .canvas-wrap { min-height: 0; }
-  .title-actions .ghost { padding: 3px 5px; font-size: 12px; }
-  .tool-btn { min-height: 40px; font-size: 16px; }
-  .group { gap: 2px; }
-  .group-title { font-size: 9px; margin-bottom: 1px; }
-  .row { gap: 4px !important; flex-wrap: wrap; }
-  input[type="number"], select { padding: 2px 3px; font-size: 11px; }
-  .num { width: 45px; }
-  input[type="range"] { width: 80px; }
-  label { font-size: 11px; gap: 3px; }
-  .canvas-wrap { min-height: 150px; flex: 1; }
-  body.edit-mode .canvas-wrap#outputWrap { min-height: 200px; }
-  body.edit-mode .canvas-wrap#outputWrap .canvas-surface { min-height: 200px; }
-  .panel-header { padding: 4px 6px; font-size: 10px; }
-  .bg-selector { gap: 2px; }
-  .bg-btn { padding: 1px 3px; font-size: 10px; min-width: 18px; height: 18px; }
-  .bg-color-picker { width: 18px; height: 18px; }
-  .workspace { gap: 6px; }
-
-  /* Mobile tool strip in canvas header */
+  .canvas-wrap { border-radius: 12px; }
+  .canvas-surface { padding: 6px; }
+  .workspace { gap: 8px; padding-bottom: calc(184px + env(safe-area-inset-bottom)); }
+  body.edit-mode .workspace { padding-bottom: calc(216px + env(safe-area-inset-bottom)); }
+  .panel-header { padding: 6px 8px; font-size: 11px; }
+  .bg-selector { gap: 4px; }
+  .bg-btn { padding: 2px; min-width: 24px; height: 24px; }
+  .bg-icon { width: 16px; height: 16px; }
+  .bg-color-picker { width: 24px; height: 24px; }
+  input[type="number"], select { padding: 2px 4px; font-size: 12px; }
+  .num { width: 54px; }
+  input[type="range"] { width: 100%; }
+  label { font-size: 12px; gap: 4px; }
+  .tool-btn { min-height: 44px; font-size: 16px; }
   .mobile-tools { display: none !important; }
-  .mobile-bottom-bar { display: flex; position: fixed; }
-  .workspace { gap: 6px; padding-bottom: 76px; }
+  .mobile-bottom-bar { display: flex; }
+  .floating-open { bottom: calc(104px + env(safe-area-inset-bottom)); right: 16px; width: 52px; height: 52px; }
 }
 
 /* Desktop: hide mobile-only strip */


### PR DESCRIPTION
## Summary
- refresh the convert step with simplified labels, background swatches, and a new preview-only view mode so the canvases can use more space
- cap aspect presets to ratio-aware templates, surface the loaded image ratio, and replace emoji icons with SVGs across layer controls and background toggles for a cleaner Figma-like feel
- tune the mobile editor bottom bar, color picker interaction, and status text so the pixel editor is easier to use on phones and hides convert-only messaging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca2fd1ea008327997872b21c6a6503