### PR TITLE
Fix floating add image button

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,6 +44,7 @@
   let colorHistory = [];
   const COLOR_HISTORY_MAX = 48;
   const openFileBtn = document.getElementById('openFileBtn');
+  const addImageBtn = document.getElementById('addImageBtn');
   const exportToggle = document.getElementById('exportToggle');
   const exportPopover = document.getElementById('exportPopover');
   // Mobile bottom bar controls
@@ -914,17 +915,23 @@
   undoBtn.addEventListener('click', undoPaint);
   redoBtn.addEventListener('click', redoPaint);
   clearPaintBtn.addEventListener('click', clearPaint);
-  if (openFileBtn) {
-    openFileBtn.addEventListener('click', () => {
-      console.log('Open file button clicked');
-      if (fileInput) {
-        console.log('File input found, triggering click');
-        fileInput.click();
-      } else {
-        console.error('File input not found');
-        statusText.textContent = 'エラー: ファイル入力が見つかりません';
-      }
-    });
+  const fileOpenButtons = [openFileBtn, addImageBtn].filter(Boolean);
+  const triggerFileDialog = () => {
+    if (!fileInput) {
+      console.error('File input not found');
+      if (statusText) statusText.textContent = 'エラー: ファイル入力が見つかりません';
+      return;
+    }
+    try {
+      fileInput.value = '';
+      fileInput.click();
+    } catch (err) {
+      console.error('Failed to trigger file dialog', err);
+      if (statusText) statusText.textContent = 'エラー: ファイル選択を開けません';
+    }
+  };
+  if (fileOpenButtons.length) {
+    fileOpenButtons.forEach(btn => btn.addEventListener('click', triggerFileDialog));
   } else {
     console.error('Open file button not found');
   }

--- a/index.html
+++ b/index.html
@@ -244,6 +244,7 @@
       </div>
     </div>
 
+    <button type="button" id="addImageBtn" class="floating-add-btn" title="画像を追加">画像を追加</button>
     <script src="app.js"></script>
   </body>
   </html>

--- a/styles.css
+++ b/styles.css
@@ -117,6 +117,32 @@ button { background: var(--accent); border: none; color: #09310e; padding: 8px 1
 .ghost { background: transparent; color: #94a3b8; border: 1px solid #1f2937; }
 .primary { background: #2563eb; color: #e5e7eb; }
 .num { width: 88px; }
+.floating-add-btn {
+  position: fixed;
+  right: 24px;
+  bottom: calc(48px + env(safe-area-inset-bottom));
+  background: #2563eb;
+  color: #e5e7eb;
+  border-radius: 999px;
+  padding: 12px 20px;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  z-index: 150;
+}
+.floating-add-btn::before {
+  content: '+';
+  font-size: 16px;
+}
+.floating-add-btn:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.6);
+  outline-offset: 4px;
+}
+.floating-add-btn:hover {
+  background: #1d4ed8;
+}
 .stepper button { padding: 4px 8px; margin-left: 4px; background: #374151; color: #e5e7eb; border-radius: 6px; border: 1px solid #1f2937; }
 .stepper button:hover { background: #4b5563; }
 
@@ -205,6 +231,12 @@ body:not(.edit-mode) #layersToggle, body:not(.edit-mode) #layersPopover { displa
   .mobile-tools { display: none !important; }
   .mobile-bottom-bar { display: flex; position: fixed; }
   .workspace { gap: 6px; padding-bottom: 76px; }
+  .floating-add-btn {
+    right: 16px;
+    bottom: calc(128px + env(safe-area-inset-bottom));
+    padding: 12px 18px;
+    font-size: 13px;
+  }
 }
 
 /* Desktop: hide mobile-only strip */


### PR DESCRIPTION
## Summary
- add a dedicated floating "画像を追加" button in the updated UI and style it for desktop/mobile placements
- wire both the titlebar and floating add buttons to the hidden file input with extra error handling so the file picker opens reliably

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ca658d86808327ac0480f49af218cf