### PR TITLE
Fix image upload button by removing duplicate clamp declaration

### DIFF
--- a/app.js
+++ b/app.js
@@ -1472,7 +1472,6 @@
   let lastOutputSize = { w: 0, h: 0 };
   const MIN_TOUCH_SCALE = 0.2;
   const MAX_TOUCH_SCALE = 16;
-  const clamp = (v, min, max) => Math.min(max, Math.max(min, v));
 
   function applyCanvasTransform() {
     if (!outputCanvas) return;


### PR DESCRIPTION
## Summary
- remove the redundant clamp helper declaration in the gesture handling code so the app initializes normally again

## Testing
- manual: opened the app and confirmed the floating image upload button now triggers the hidden file input


------
https://chatgpt.com/codex/tasks/task_e_68ca694e0cc08327911fbb8b95081e6f