### PR TITLE
Fix image loader button by clearing file input before opening dialog

### DIFF
--- a/app.js
+++ b/app.js
@@ -1144,6 +1144,8 @@
       console.log('Open file button clicked');
       if (fileInput) {
         console.log('File input found, triggering click');
+        // Reset value so selecting the same file triggers a change event again
+        fileInput.value = '';
         fileInput.click();
       } else {
         console.error('File input not found');


### PR DESCRIPTION
## Summary
- clear the hidden file input value before programmatically clicking it from the floating "open image" button
- allow selecting the same image consecutively so the change event fires every time and the converter refreshes

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68ca6e77f8c08327979687eccfb3db37