### PR TITLE
Adjust convert layout and background controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,9 +306,6 @@
                   <button class="bg-btn" data-bg="checker" title="チェッカー(透明)">▦</button>
                   <button class="bg-btn" data-bg="white" title="白">□</button>
                   <button class="bg-btn" data-bg="black" title="黒">■</button>
-                  <button class="bg-btn" data-bg="lightgray" title="薄灰">▥</button>
-                  <button class="bg-btn" data-bg="gray" title="濃灰">▨</button>
-                  <input type="color" id="bgColorPicker" class="bg-color-picker" title="カスタム色">
                 </div>
               </div>
               <div class="canvas-surface checker" id="outputSurface"><canvas id="outputCanvas" width="32" height="32" class="pixelated"></canvas></div>

--- a/styles.css
+++ b/styles.css
@@ -14,6 +14,11 @@ body {
   overscroll-behavior: none;
 }
 
+body:not(.edit-mode) {
+  height: auto;
+  min-height: 100vh;
+}
+
 .icon { width: 20px; height: 20px; display: block; flex-shrink: 0; }
 .compact .icon { width: 18px; height: 18px; }
 
@@ -21,6 +26,7 @@ button.compact { padding: 6px 8px; border-radius: 8px; }
 
 /* App shell */
 .app-frame { display: grid; grid-template-rows: 44px 1fr 26px; height: 100vh; height: 100svh; position: relative; }
+body:not(.edit-mode) .app-frame { height: auto; min-height: 100vh; }
 .titlebar {
   display: flex; align-items: center; justify-content: space-between;
   padding: 0 12px; border-bottom: 1px solid #1f2937; background: linear-gradient(180deg, #0b1220, #0a0f1a);
@@ -32,7 +38,7 @@ button.compact { padding: 6px 8px; border-radius: 8px; }
 .popover-title { font-size: 12px; color: var(--muted); }
 
 .main { display: grid; grid-template-columns: 72px 1fr 320px; gap: 12px; padding: 12px; overflow: hidden; min-height: 0; }
-body:not(.edit-mode) .main { grid-template-columns: 1fr; }
+body:not(.edit-mode) .main { grid-template-columns: 1fr; overflow: visible; }
 
 /* Sidebar (tools) */
 .sidebar { background: var(--card); border: 1px solid #1f2937; border-radius: 10px; padding: 8px; display: flex; flex-direction: column; gap: 10px; overflow: hidden; }
@@ -47,6 +53,7 @@ body:not(.edit-mode) .main { grid-template-columns: 1fr; }
 
 /* Workspace */
 .workspace { display: grid; grid-template-rows: auto minmax(0, auto) 1fr; gap: 12px; min-width: 0; min-height: 0; }
+body:not(.edit-mode) .workspace { grid-template-rows: auto auto auto; }
 .mode-bar { background: var(--card); border: 1px solid #1f2937; border-radius: 10px; padding: 8px; position: sticky; top: 0; z-index: 10; }
 .topbar { background: var(--card); border: 1px solid #1f2937; border-radius: 12px; padding: 12px; display: grid; gap: 12px; overflow-y: auto; max-height: 42vh; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); align-content: start; }
 .control-card { background: #0b1220; border: 1px solid #1f2937; border-radius: 12px; display: flex; flex-direction: column; gap: 0; min-width: 0; }
@@ -87,11 +94,13 @@ body:not(.edit-mode) .main { grid-template-columns: 1fr; }
 .mobile-bottom-bar .divider { width: 1px; height: 32px; background: #1f2937; flex: 0 0 auto; }
 .mobile-bottom-bar .color-chip { min-width: 44px; min-height: 44px; border-radius: 10px; border: 1px solid #1f2937; }
 
-.canvas-area { display: grid; gap: 12px; min-height: 0; grid-template-columns: 1fr; grid-template-rows: repeat(2, minmax(0, 1fr)); }
-.canvas-area[data-view="stack"] .canvas-wrap { min-height: clamp(240px, 45vh, 520px); }
+.canvas-area { display: grid; gap: 12px; min-height: 0; grid-template-columns: 1fr; }
+.canvas-area[data-view="stack"] { grid-auto-rows: auto; align-content: start; }
+.canvas-area[data-view="stack"] .canvas-wrap { min-height: 240px; grid-template-rows: auto auto; }
+.canvas-area[data-view="stack"] .canvas-surface { height: auto; }
+.canvas-area[data-view="split"] { grid-template-columns: repeat(2, minmax(0, 1fr)); grid-auto-rows: minmax(0, 1fr); }
 .canvas-area[data-view="split"] .canvas-wrap { min-height: clamp(240px, 60vh, 520px); }
 .canvas-area[data-view="output"] .canvas-wrap { min-height: clamp(260px, 60vh, 560px); }
-.canvas-area[data-view="split"] { grid-template-columns: repeat(2, minmax(0, 1fr)); grid-template-rows: 1fr; }
 .canvas-area[data-view="preview"] #outputWrap { display: none; }
 .canvas-area[data-view="output"] #previewWrap { display: none; }
 .canvas-area .canvas-wrap { min-height: 0; }
@@ -106,7 +115,6 @@ body:not(.edit-mode) .main { grid-template-columns: 1fr; }
 .bg-btn { background: #0b1220; border: 1px solid #1f2937; color: #e5e7eb; border-radius: 4px; padding: 4px 8px; cursor: pointer; font-size: 14px; min-width: 24px; height: 24px; }
 .bg-btn:hover { background: #1f2937; }
 .bg-btn.active { outline: 2px solid #2563eb; }
-.bg-color-picker { width: 24px; height: 24px; padding: 0; border: 1px solid #1f2937; border-radius: 4px; cursor: pointer; }
 .collapse-btn { background: transparent; border: 1px solid #1f2937; color: #94a3b8; border-radius: 6px; width: 22px; height: 22px; display: grid; place-items: center; cursor: pointer; }
 .collapse-btn::before { content: '▾'; line-height: 1; }
 .panel.collapsed .collapse-btn { transform: rotate(-90deg); }
@@ -115,9 +123,6 @@ body:not(.edit-mode) .main { grid-template-columns: 1fr; }
 .checker { background-image: linear-gradient(45deg,#111827 25%,transparent 25%),linear-gradient(-45deg,#111827 25%,transparent 25%),linear-gradient(45deg,transparent 75%,#111827 75%),linear-gradient(-45deg,transparent 75%,#111827 75%); background-size: 20px 20px; background-position: 0 0,0 10px,10px -10px,-10px 0px; }
 .bg-white { background: white !important; background-image: none !important; }
 .bg-black { background: black !important; background-image: none !important; }
-.bg-gray { background: #374151 !important; background-image: none !important; }
-/* Additional preset */
-.bg-lightgray { background: #9ca3af !important; background-image: none !important; }
 canvas { display: block; max-width: 100%; max-height: 100%; width: auto; height: auto; background: #0b1220; border: 1px solid #1f2937; border-radius: 6px; }
 canvas { transform-origin: 0 0; }
 .canvas-surface { overscroll-behavior: contain; }
@@ -168,17 +173,17 @@ body:not(.edit-mode) .sidebar { display: none; }
 
 /* Layer list */
 .layer-list { display: grid; gap: 6px; }
-.layer-item { display: grid; grid-template-columns: 48px 1fr auto; align-items: center; gap: 8px; padding: 6px 8px; border: 1px solid #1f2937; border-radius: 8px; background: #0b1220; cursor: pointer; min-height: 58px; }
+.layer-item { display: grid; grid-template-columns: 40px 1fr auto; align-items: center; gap: 6px; padding: 6px; border: 1px solid #1f2937; border-radius: 8px; background: #0b1220; cursor: pointer; min-height: 48px; }
 .layer-item.selected { outline: 2px solid #2563eb; background: #0f1a2e; }
-.layer-thumb { width: 48px; height: 48px; border-radius: 6px; overflow: hidden; background: #111827; display: grid; place-items: center; }
-.layer-thumb canvas { width: 48px; height: 48px; image-rendering: pixelated; }
+.layer-thumb { width: 40px; height: 40px; border-radius: 6px; overflow: hidden; background: #111827; display: grid; place-items: center; }
+.layer-thumb canvas { width: 40px; height: 40px; image-rendering: pixelated; }
 .layer-meta { display: flex; flex-direction: column; gap: 2px; }
 .layer-name { font-size: 12px; color: #e5e7eb; }
 .layer-tags { font-size: 10px; color: #94a3b8; }
-.layer-eye { background: transparent; border: 1px solid #1f2937; color: #94a3b8; border-radius: 6px; width: 26px; height: 26px; display: grid; place-items: center; cursor: pointer; }
+.layer-eye { background: transparent; border: 1px solid #1f2937; color: #94a3b8; border-radius: 6px; width: 24px; height: 24px; display: grid; place-items: center; cursor: pointer; }
 .layer-eye svg { width: 16px; height: 16px; }
 .layer-item.is-hidden .layer-eye { color: #f87171; }
-.layer-btn { background: transparent; border: 1px solid #1f2937; color: #94a3b8; border-radius: 6px; width: 26px; height: 26px; display: grid; place-items: center; cursor: pointer; font-size: 14px; }
+.layer-btn { background: transparent; border: 1px solid #1f2937; color: #94a3b8; border-radius: 6px; width: 24px; height: 24px; display: grid; place-items: center; cursor: pointer; font-size: 14px; }
 .edit-mode .normalize-only { display: none !important; }
 .edit-mode #outputWrap { grid-column: 1 / -1; }
 .edit-mode #outputWrap .canvas-surface { display: flex; align-items: center; justify-content: center; }
@@ -201,7 +206,7 @@ body:not(.edit-mode) .topbar { max-height: 48vh; overflow: auto; }
 .layer-modal .layer-modal-header { display: flex; align-items: center; justify-content: space-between; padding: 10px 12px; background: var(--card); border-bottom: 1px solid #1f2937; }
 .layer-modal .layer-modal-footer { display: flex; gap: 8px; padding: 10px 12px calc(10px + env(safe-area-inset-bottom)); background: var(--card); border-top: 1px solid #1f2937; }
 .layer-modal .layer-list.mobile { overflow: auto; padding: 8px; background: #0b1220; }
-.layer-list.mobile .layer-item { grid-template-columns: 48px 1fr auto auto; min-height: 58px; padding: 8px; }
+.layer-list.mobile .layer-item { grid-template-columns: 40px 1fr auto auto; min-height: 52px; padding: 8px; }
 .layer-list.mobile .layer-name { font-size: 14px; }
 .layer-list.mobile .layer-eye, .layer-list.mobile .layer-btn { width: 32px; height: 32px; }
 .layer-list.mobile .layer-eye svg { width: 18px; height: 18px; }
@@ -213,6 +218,7 @@ body:not(.edit-mode) .topbar { max-height: 48vh; overflow: auto; }
   .app-frame { grid-template-rows: 44px 1fr; height: 100vh; height: 100svh; }
   .statusbar { display: none; }
   .main { grid-template-columns: 1fr; padding: 8px 10px 12px; overflow-y: auto; }
+  body:not(.edit-mode) .main { overflow-y: auto; }
   .sidebar, .panels { display: none !important; }
   .topbar { padding: 8px; gap: 8px; max-height: 50vh; grid-template-columns: 1fr; }
   .control-card .card-body { gap: 8px; }
@@ -227,7 +233,6 @@ body:not(.edit-mode) .topbar { max-height: 48vh; overflow: auto; }
   .panel-header { padding: 6px 8px; font-size: 11px; }
   .bg-selector { gap: 4px; }
   .bg-btn { padding: 2px 4px; font-size: 11px; min-width: 20px; height: 20px; }
-  .bg-color-picker { width: 20px; height: 20px; }
   input[type="number"], select { padding: 2px 4px; font-size: 12px; }
   .num { width: 54px; }
   input[type="range"] { width: 100%; }


### PR DESCRIPTION
## Summary
- allow the convert step to use vertical space so stacked canvases keep their natural size
- simplify the background selector to checker/white/black and fix color swatch activation
- shorten layer cards and update thumbnails for a denser layer list

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca8b423edc8327a432d2969293b8ec