### PR TITLE
Adjust mobile toolbar visibility and layer layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,7 +52,9 @@
   const mobileBrushDec = document.getElementById('mobileBrushDec');
   const mobileBrushInc = document.getElementById('mobileBrushInc');
   const mobileBrushSize = document.getElementById('mobileBrushSize');
+  const mobileBrushGroup = document.getElementById('mobileBrushControls');
   const mobileColorBtn = document.getElementById('mobileColorBtn');
+  const mobileColorGroup = document.getElementById('mobileColorControls');
   const layersToggleMobile = document.getElementById('layersToggleMobile');
   const layersModal = document.getElementById('layersModal');
   const closeLayersModal = document.getElementById('closeLayersModal');
@@ -113,6 +115,29 @@
     mobileColorBtn.style.background = colorInput.value;
     const a = alphaInput ? parseInt(alphaInput.value||'255',10) : 255;
     mobileColorBtn.style.backgroundImage = (a < 252) ? 'repeating-linear-gradient(45deg, rgba(0,0,0,0.35) 0 2px, transparent 2px 6px)' : 'none';
+  }
+
+  function parseToolTargets(panel, fallbackTargets = []) {
+    if (!panel || !panel.dataset) return new Set(fallbackTargets);
+    const value = panel.dataset.toolTarget || '';
+    if (!value) return new Set(fallbackTargets);
+    return new Set(value.split(',').map(s => s.trim()).filter(Boolean));
+  }
+
+  const colorToolTargets = parseToolTargets(colorInput?.closest('.tool-option'), ['pen', 'line', 'rect', 'fill']);
+  const brushToolTargets = parseToolTargets(brushSizeInput?.closest('.tool-option'), ['pen']);
+
+  function toggleHidden(el, hidden) {
+    if (!el) return;
+    el.classList.toggle('hidden', hidden);
+  }
+
+  function updateMobileToolVisibility() {
+    const tool = toolSelect?.value || '';
+    const showBrush = brushToolTargets.size === 0 || brushToolTargets.has(tool);
+    const showColor = colorToolTargets.size === 0 || colorToolTargets.has(tool);
+    toggleHidden(mobileBrushGroup, !showBrush);
+    toggleHidden(mobileColorGroup, !showColor);
   }
 
   function updateToolOptions() {
@@ -1750,6 +1775,7 @@
       syncToolButtons();
       updateStatus();
       updateToolOptions();
+      updateMobileToolVisibility();
       // cursor
       if (toolSelect.value === 'move') {
         outputCanvas.style.cursor = 'move';
@@ -1762,6 +1788,7 @@
     // initial state
     syncToolButtons();
     updateToolOptions();
+    updateMobileToolVisibility();
   }
 
   // Status bar

--- a/index.html
+++ b/index.html
@@ -396,22 +396,26 @@
             <path d="M14.9 5.1l1.8-1.8a1.8 1.8 0 012.6 0l.4.4a1.8 1.8 0 010 2.6L17.9 8" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
           </svg>
         </button>
-        <div class="divider"></div>
-        <button id="mobileBrushDec" type="button" title="ブラシ縮小">
-          <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M6 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
-          </svg>
-        </button>
-        <span id="mobileBrushSize" class="label">1</span>
-        <button id="mobileBrushInc" type="button" title="ブラシ拡大">
-          <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
-          </svg>
-        </button>
-        <div class="divider"></div>
-        <div class="mobile-color-picker">
-          <button id="mobileColorBtn" type="button" title="色を選択" aria-label="色を選択" class="color-chip"></button>
-          <input type="color" id="mobileColorInput" aria-label="色を選択" />
+        <div id="mobileBrushControls" class="mobile-toolbar-group">
+          <div class="divider"></div>
+          <button id="mobileBrushDec" type="button" title="ブラシ縮小">
+            <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M6 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
+            </svg>
+          </button>
+          <span id="mobileBrushSize" class="label">1</span>
+          <button id="mobileBrushInc" type="button" title="ブラシ拡大">
+            <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
+            </svg>
+          </button>
+        </div>
+        <div id="mobileColorControls" class="mobile-toolbar-group">
+          <div class="divider"></div>
+          <div class="mobile-color-picker">
+            <button id="mobileColorBtn" type="button" title="色を選択" aria-label="色を選択" class="color-chip"></button>
+            <input type="color" id="mobileColorInput" aria-label="色を選択" />
+          </div>
         </div>
         <button id="layersToggleMobile" class="ghost compact" type="button" title="レイヤー">
           <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">

--- a/styles.css
+++ b/styles.css
@@ -97,6 +97,7 @@ body:not(.edit-mode) .workspace { grid-template-rows: auto auto auto; }
 .mobile-bottom-bar .tool-btn.active { outline: 2px solid #2563eb; background: #0f1a2e; }
 .mobile-bottom-bar .label { min-width: 28px; text-align: center; color: #94a3b8; font-weight: 600; }
 .mobile-bottom-bar .divider { width: 1px; height: 32px; background: #1f2937; flex: 0 0 auto; }
+.mobile-bottom-bar .mobile-toolbar-group { display: inline-flex; align-items: center; gap: 8px; flex: 0 0 auto; }
 .mobile-bottom-bar .mobile-color-picker {
   position: relative;
   width: 44px;
@@ -200,17 +201,17 @@ body:not(.edit-mode) .sidebar { display: none; }
 
 /* Layer list */
 .layer-list { display: grid; gap: 6px; }
-.layer-item { display: grid; grid-template-columns: 40px 1fr auto; align-items: center; gap: 6px; padding: 6px; border: 1px solid #1f2937; border-radius: 8px; background: #0b1220; cursor: pointer; min-height: 48px; }
+.layer-item { display: grid; grid-template-columns: 40px 1fr repeat(3, auto); align-items: center; gap: 6px; padding: 6px; border: 1px solid #1f2937; border-radius: 8px; background: #0b1220; cursor: pointer; min-height: 48px; }
 .layer-item.selected { outline: 2px solid #2563eb; background: #0f1a2e; }
 .layer-thumb { width: 40px; height: 40px; border-radius: 6px; overflow: hidden; background: #111827; display: grid; place-items: center; }
 .layer-thumb canvas { width: 40px; height: 40px; image-rendering: pixelated; }
 .layer-meta { display: flex; flex-direction: column; gap: 2px; }
 .layer-name { font-size: 12px; color: #e5e7eb; }
 .layer-tags { font-size: 10px; color: #94a3b8; }
-.layer-eye { background: transparent; border: 1px solid #1f2937; color: #94a3b8; border-radius: 6px; width: 24px; height: 24px; display: grid; place-items: center; cursor: pointer; }
+.layer-eye { background: transparent; border: 1px solid #1f2937; color: #94a3b8; border-radius: 6px; width: 24px; height: 24px; display: grid; place-items: center; cursor: pointer; justify-self: center; }
 .layer-eye svg { width: 16px; height: 16px; display: block; }
 .layer-item.is-hidden .layer-eye { color: #f87171; }
-.layer-btn { background: transparent; border: 1px solid #1f2937; color: #94a3b8; border-radius: 6px; width: 24px; height: 24px; display: grid; place-items: center; cursor: pointer; font-size: 0; }
+.layer-btn { background: transparent; border: 1px solid #1f2937; color: #94a3b8; border-radius: 6px; width: 24px; height: 24px; display: grid; place-items: center; cursor: pointer; font-size: 0; justify-self: center; }
 .layer-btn svg { width: 16px; height: 16px; display: block; }
 .edit-mode .normalize-only { display: none !important; }
 .edit-mode #outputWrap { grid-column: 1 / -1; }
@@ -295,7 +296,7 @@ body:not(.edit-mode) .topbar { max-height: 48vh; overflow: auto; }
   flex: 1 1 120px;
 }
 .layer-modal .layer-list.mobile { overflow: auto; padding: 0; background: transparent; }
-.layer-list.mobile .layer-item { grid-template-columns: 40px 1fr auto auto; min-height: 52px; padding: 8px; }
+.layer-list.mobile .layer-item { grid-template-columns: 40px 1fr repeat(3, auto); min-height: 52px; padding: 8px; }
 .layer-list.mobile .layer-name { font-size: 14px; }
 .layer-list.mobile .layer-eye, .layer-list.mobile .layer-btn { width: 32px; height: 32px; }
 .layer-list.mobile .layer-eye svg { width: 18px; height: 18px; }


### PR DESCRIPTION
## Summary
- group the mobile toolbar brush and color controls so they can be shown or hidden together
- align the smartphone behavior with desktop by hiding mobile brush and color controls for unsupported tools
- keep layer action buttons in a single row with centered icons across desktop and mobile views

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb4764ad608327b9a839b6cfc3165e